### PR TITLE
Get away from master/slave terminology

### DIFF
--- a/Demo/gyroaccel.py
+++ b/Demo/gyroaccel.py
@@ -24,7 +24,7 @@ update_interval = float(args.interval)
 
 # Communication object
 gyro = L3GD20(busId=int(args.bus_id),
-              slaveAddr=0x6B,
+              subordinateAddr=0x6B,
               ifLog=False,
               ifWriteBlock=False)
 accel = LSM303DLHC(address_accel=0x19,

--- a/Demo/libraries/Gyrometer/Example_3DPlot.py
+++ b/Demo/libraries/Gyrometer/Example_3DPlot.py
@@ -72,7 +72,7 @@ class Simulation:
     def run(self):
         """ Main Loop """
         # Communication object
-        s = L3GD20(busId = 1, slaveAddr = 0x6b, ifLog = False, ifWriteBlock=False)
+        s = L3GD20(busId = 1, subordinateAddr = 0x6b, ifLog = False, ifWriteBlock=False)
 
         # Preconfiguration
         s.Set_PowerMode("Normal")

--- a/Demo/libraries/Gyrometer/Example_ReadConfig.py
+++ b/Demo/libraries/Gyrometer/Example_ReadConfig.py
@@ -3,7 +3,7 @@
 from L3GD20 import L3GD20
 
 # Communication object
-s = L3GD20(busId = 1, slaveAddr = 0x6b, ifLog = False, ifWriteBlock=False)
+s = L3GD20(busId = 1, subordinateAddr = 0x6b, ifLog = False, ifWriteBlock=False)
 
 # Preconfiguration
 s.Set_PowerMode("Normal")

--- a/Demo/libraries/Gyrometer/Example_ReadRawData.py
+++ b/Demo/libraries/Gyrometer/Example_ReadRawData.py
@@ -6,7 +6,7 @@ import numpy
 import matplotlib.pylab as plt
 
 # Communication object
-s = L3GD20(busId = 1, slaveAddr = 0x6b, ifLog = False, ifWriteBlock=False)
+s = L3GD20(busId = 1, subordinateAddr = 0x6b, ifLog = False, ifWriteBlock=False)
 
 # Preconfiguration
 s.Set_PowerMode("Normal")

--- a/Demo/libraries/Gyrometer/Example_ReadRealData.py
+++ b/Demo/libraries/Gyrometer/Example_ReadRealData.py
@@ -5,7 +5,7 @@ from L3GD20 import L3GD20
 import time
 
 # Communication object
-s = L3GD20(busId = 1, slaveAddr = 0x6b, ifLog = False, ifWriteBlock=False)
+s = L3GD20(busId = 1, subordinateAddr = 0x6b, ifLog = False, ifWriteBlock=False)
 
 # Preconfiguration
 s.Set_PowerMode("Normal")

--- a/Demo/libraries/Gyrometer/L3GD20.py
+++ b/Demo/libraries/Gyrometer/L3GD20.py
@@ -7,9 +7,9 @@ import time
 
 class L3GD20(object):
     
-    def __init__(self, busId, slaveAddr, ifLog, ifWriteBlock):
+    def __init__(self, busId, subordinateAddr, ifLog, ifWriteBlock):
         self.__i2c = SMBus(busId)
-        self.__slave = slaveAddr
+        self.__subordinate = subordinateAddr
         self.__ifWriteBlock = ifWriteBlock
         self.__ifLog = ifLog
         self.__x0 = 0
@@ -25,15 +25,15 @@ class L3GD20(object):
         print('Change in register:' + register + ' mask:' + mask + ' from:' + current + ' to:' + new)
         
     def __writeToRegister(self, register, mask, value):
-        current = self.__i2c.read_byte_data(self.__slave, register)  # Get current value
+        current = self.__i2c.read_byte_data(self.__subordinate, register)  # Get current value
         new = bitOps.SetValueUnderMask(value, current, mask)
         if self.__ifLog:
             self.__log(register, mask, current, new)
         if  not self.__ifWriteBlock:
-            self.__i2c.write_byte_data(self.__slave, register, new)
+            self.__i2c.write_byte_data(self.__subordinate, register, new)
         
     def __readFromRegister(self, register, mask):
-        current = self.__i2c.read_byte_data(self.__slave, register)   # Get current value
+        current = self.__i2c.read_byte_data(self.__subordinate, register)   # Get current value
         return bitOps.GetValueUnderMask(current, mask)
 
     


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.